### PR TITLE
Cypress Includes for External Validation

### DIFF
--- a/app/models/calculated_product_test.rb
+++ b/app/models/calculated_product_test.rb
@@ -20,7 +20,7 @@ class CalculatedProductTest < ProductTest
   after_create :gen_pop
 
   def gen_pop
-    self.generate_population
+    self.generate_population if should_generate_population?
   end
 
   def calculate_expected_results
@@ -130,5 +130,13 @@ class CalculatedProductTest < ProductTest
 
   def read_qrda_file_contents(qrda_file)
     qrda_file.respond_to?(:open) ? qrda_file.open.read : qrda_file.read
+  end
+
+  def should_generate_population?
+    return !population_already_generated?
+  end
+
+  def population_already_generated?
+    state == :ready
   end
 end

--- a/app/models/calculated_product_test.rb
+++ b/app/models/calculated_product_test.rb
@@ -60,7 +60,7 @@ class CalculatedProductTest < ProductTest
   end
 
   def execute(qrda_file)
-    data = qrda_file.open.read
+    data = read_qrda_file_contents(qrda_file)
     doc = Nokogiri::XML(data)
     te = self.test_executions.build(expected_results:self.expected_results,
      execution_date: Time.now.to_i)
@@ -128,4 +128,7 @@ class CalculatedProductTest < ProductTest
     res_clone.save
   end
 
+  def read_qrda_file_contents(qrda_file)
+    qrda_file.respond_to?(:open) ? qrda_file.open.read : qrda_file.read
+  end
 end

--- a/app/models/calculated_product_test.rb
+++ b/app/models/calculated_product_test.rb
@@ -60,7 +60,6 @@ class CalculatedProductTest < ProductTest
   end
 
   def execute(qrda_file)
-
     data = qrda_file.open.read
     doc = Nokogiri::XML(data)
     te = self.test_executions.build(expected_results:self.expected_results,

--- a/app/models/calculated_product_test.rb
+++ b/app/models/calculated_product_test.rb
@@ -54,9 +54,11 @@ class CalculatedProductTest < ProductTest
   end
 
   def validators(doc)
-    @validators ||= [::Validators::QrdaCat3Validator.new(expected_results),
-      ::Validators::MeasurePeriodValidator.new(),
-      ::Validators::ExpectedResultsValidator.new(expected_results)]
+    @validators ||= [
+      ::Validators::QrdaCat3Validator.new(expected_results),
+      ::Validators::MeasurePeriodValidator.new,
+      ::Validators::ExpectedResultsValidator.new(expected_results)
+    ]
   end
 
   def execute(qrda_file)
@@ -133,7 +135,7 @@ class CalculatedProductTest < ProductTest
   end
 
   def should_generate_population?
-    return !population_already_generated?
+    !population_already_generated?
   end
 
   def population_already_generated?

--- a/app/models/calculated_product_test.rb
+++ b/app/models/calculated_product_test.rb
@@ -54,11 +54,9 @@ class CalculatedProductTest < ProductTest
   end
 
   def validators(doc)
-    @validators ||= [
-      ::Validators::QrdaCat3Validator.new(expected_results),
-      ::Validators::MeasurePeriodValidator.new,
-      ::Validators::ExpectedResultsValidator.new(expected_results)
-    ]
+    @validators ||= [::Validators::QrdaCat3Validator.new(expected_results),
+      ::Validators::MeasurePeriodValidator.new(),
+      ::Validators::ExpectedResultsValidator.new(expected_results)]
   end
 
   def execute(qrda_file)

--- a/app/models/qrda_product_test.rb
+++ b/app/models/qrda_product_test.rb
@@ -1,5 +1,5 @@
-require 'validators/smoking_gun_validator'
-require 'validators/qrda_cat1_validator'
+require_relative '../../lib/validators/smoking_gun_validator'
+require_relative '../../lib/validators/qrda_cat1_validator'
 
 class QRDAProductTest < ProductTest
   include Mongoid::Attributes::Dynamic

--- a/app/models/qrda_product_test.rb
+++ b/app/models/qrda_product_test.rb
@@ -1,10 +1,6 @@
-require_relative '../../lib/validators/smoking_gun_validator'
-require_relative '../../lib/validators/qrda_cat1_validator'
-
 class QRDAProductTest < ProductTest
   include Mongoid::Attributes::Dynamic
   include ::Validators
-
 
   belongs_to :calculated_product_test, foreign_key: "calculated_test_id", index: true
 

--- a/app/models/qrda_product_test.rb
+++ b/app/models/qrda_product_test.rb
@@ -1,13 +1,12 @@
 class QRDAProductTest < ProductTest
   include Mongoid::Attributes::Dynamic
-  include ::Validators
 
   belongs_to :calculated_product_test, foreign_key: "calculated_test_id", index: true
 
   def validators
-    @validators ||= [QrdaCat1Validator.new(self.bundle, self.measures, self.parent_measures),
-    SmokingGunValidator.new(self.measures, self.records, self.id),
-    MeasurePeriodValidator.new()]
+    @validators ||= [::Validators::QrdaCat1Validator.new(self.bundle, self.measures, self.parent_measures),
+    ::Validators::SmokingGunValidator.new(self.measures, self.records, self.id),
+    ::Validators::MeasurePeriodValidator.new()]
   end
 
   def execute(file)

--- a/app/models/qrda_product_test.rb
+++ b/app/models/qrda_product_test.rb
@@ -4,9 +4,11 @@ class QRDAProductTest < ProductTest
   belongs_to :calculated_product_test, foreign_key: "calculated_test_id", index: true
 
   def validators
-    @validators ||= [::Validators::QrdaCat1Validator.new(self.bundle, self.measures, self.parent_measures),
-    ::Validators::SmokingGunValidator.new(self.measures, self.records, self.id),
-    ::Validators::MeasurePeriodValidator.new()]
+    @validators ||= [
+      ::Validators::QrdaCat1Validator.new(bundle, measures, parent_measures),
+      ::Validators::SmokingGunValidator.new(measures, records, id),
+      ::Validators::MeasurePeriodValidator.new
+    ]
   end
 
   def execute(file)

--- a/app/uploaders/document_uploader.rb
+++ b/app/uploaders/document_uploader.rb
@@ -6,7 +6,7 @@ class DocumentUploader < CarrierWave::Uploader::Base
   process :set_content_type
 
   def store_dir
-    "#{APP_CONFIG['file_upload_root']}/test_executions/#{model.id}"
+    "#{::APP_CONFIG['file_upload_root']}/test_executions/#{model.id}"
   end
 
   def extension_white_list

--- a/lib/includes_for_external_validation.rb
+++ b/lib/includes_for_external_validation.rb
@@ -4,9 +4,6 @@ require 'devise'
 require 'devise/orm/mongoid'
 require 'carrierwave'
 require 'carrierwave/mongoid'
-require 'health-data-standards'
-require 'health-data-standards/hqmf-parser'
-require 'quality-measure-engine'
 
 module Cypress
   Bundle = HealthDataStandards::CQM::Bundle
@@ -58,7 +55,6 @@ end
   './ext/measure.rb'
 ].each { |relative_path| load_external_validation_dependency(relative_path) }
 
-Measure = Cypress::Measure
 QRDAProductTest = Cypress::QRDAProductTest
 InpatientProductTest = Cypress::InpatientProductTest
 module Validators

--- a/lib/includes_for_external_validation.rb
+++ b/lib/includes_for_external_validation.rb
@@ -1,11 +1,16 @@
 # gems
 require 'aasm'
+require 'devise'
+require 'devise/orm/mongoid'
 require 'carrierwave'
 require 'carrierwave/mongoid'
 require 'health-data-standards'
 require 'quality-measure-engine'
 
-module Cypress; end
+module Cypress
+  Bundle = HealthDataStandards::CQM::Bundle
+end
+
 module Validators; end
 
 def load_into_cypress_namespace(absolute_path)
@@ -30,6 +35,10 @@ end
   # product tests
   '../app/models/product.rb',
   '../app/models/product_test.rb',
+  '../app/models/vendor.rb',
+  '../app/models/user.rb',
+  '../app/models/note.rb',
+  '../app/models/patient_population.rb',
   '../app/models/calculated_product_test.rb',
   '../app/models/inpatient_product_test.rb',
   '../app/models/qrda_product_test.rb',

--- a/lib/includes_for_external_validation.rb
+++ b/lib/includes_for_external_validation.rb
@@ -5,19 +5,38 @@ require 'carrierwave/mongoid'
 require 'health-data-standards'
 require 'quality-measure-engine'
 
-# validators
-require_relative 'validators/validator'
-require_relative 'validators/smoking_gun_validator'
-require_relative 'validators/qrda_file_validator'
+module Cypress; end
+module Validators; end
 
-# product tests
-require_relative '../app/models/product_test'
-require_relative '../app/models/calculated_product_test'
-require_relative '../app/models/inpatient_product_test'
-require_relative '../app/models/qrda_product_test'
+def load_into_cypress_namespace(absolute_path)
+  Cypress.module_eval File.read(absolute_path)
+end
 
-# execution
-require_relative '../app/models/test_execution'
-require_relative '../app/uploaders/document_uploader'
-require_relative '../app/models/artifact'
-require_relative '../app/models/execution_error'
+def absolute_cypress_path(relative_path)
+  File.expand_path(relative_path, File.dirname(__FILE__))
+end
+
+def load_external_validation_dependency(relative_path)
+  load_into_cypress_namespace(absolute_cypress_path(relative_path))
+end
+
+[
+  # validators
+  './validators/validator.rb',
+  './validators/smoking_gun_validator.rb',
+  './cypress/qrda_file_constants.rb',
+  './validators/qrda_file_validator.rb',
+
+  # product tests
+  '../app/models/product.rb',
+  '../app/models/product_test.rb',
+  '../app/models/calculated_product_test.rb',
+  '../app/models/inpatient_product_test.rb',
+  '../app/models/qrda_product_test.rb',
+
+  # execution
+  '../app/models/test_execution.rb',
+  '../app/uploaders/document_uploader.rb',
+  '../app/models/artifact.rb',
+  '../app/models/execution_error.rb'
+].each { |relative_path| load_external_validation_dependency(relative_path) }

--- a/lib/includes_for_external_validation.rb
+++ b/lib/includes_for_external_validation.rb
@@ -5,22 +5,33 @@ require 'devise/orm/mongoid'
 require 'carrierwave'
 require 'carrierwave/mongoid'
 
-module Cypress
-  Bundle = HealthDataStandards::CQM::Bundle
-end
-
 module Validators; end
 
-def load_into_cypress_namespace(absolute_path)
-  Cypress.module_eval File.read(absolute_path)
-end
+module Cypress
+  Bundle = HealthDataStandards::CQM::Bundle
 
-def absolute_cypress_path(relative_path)
-  File.expand_path(relative_path, File.dirname(__FILE__))
-end
+  def factory_path
+    absolute_cypress_path('../test/factories')
+  end
 
-def load_external_validation_dependency(relative_path)
-  load_into_cypress_namespace(absolute_cypress_path(relative_path))
+  def load_into_cypress_namespace(absolute_path)
+    Cypress.module_eval File.read(absolute_path)
+  end
+
+  def absolute_cypress_path(relative_path)
+    File.expand_path(relative_path, File.dirname(__FILE__))
+  end
+
+  def load_external_validation_dependency(relative_path)
+    load_into_cypress_namespace(absolute_cypress_path(relative_path))
+  end
+
+  %i(
+    factory_path
+    load_into_cypress_namespace
+    absolute_cypress_path
+    load_external_validation_dependency
+  ).each { |method| module_function method }
 end
 
 [
@@ -53,7 +64,9 @@ end
 
   # monkey patches :(
   './ext/measure.rb'
-].each { |relative_path| load_external_validation_dependency(relative_path) }
+].each do |relative_path|
+  Cypress.load_external_validation_dependency(relative_path)
+end
 
 QRDAProductTest = Cypress::QRDAProductTest
 InpatientProductTest = Cypress::InpatientProductTest

--- a/lib/includes_for_external_validation.rb
+++ b/lib/includes_for_external_validation.rb
@@ -70,6 +70,7 @@ end
 
 QRDAProductTest = Cypress::QRDAProductTest
 InpatientProductTest = Cypress::InpatientProductTest
+CalculatedProductTest = Cypress::CalculatedProductTest
 module Validators
   include Cypress::Validators
 end

--- a/lib/includes_for_external_validation.rb
+++ b/lib/includes_for_external_validation.rb
@@ -1,0 +1,23 @@
+# gems
+require 'aasm'
+require 'carrierwave'
+require 'carrierwave/mongoid'
+require 'health-data-standards'
+require 'quality-measure-engine'
+
+# validators
+require_relative 'validators/validator'
+require_relative 'validators/smoking_gun_validator'
+require_relative 'validators/qrda_file_validator'
+
+# product tests
+require_relative '../app/models/product_test'
+require_relative '../app/models/calculated_product_test'
+require_relative '../app/models/inpatient_product_test'
+require_relative '../app/models/qrda_product_test'
+
+# execution
+require_relative '../app/models/test_execution'
+require_relative '../app/uploaders/document_uploader'
+require_relative '../app/models/artifact'
+require_relative '../app/models/execution_error'

--- a/lib/includes_for_external_validation.rb
+++ b/lib/includes_for_external_validation.rb
@@ -51,11 +51,18 @@ end
   '../app/models/test_execution.rb',
   '../app/uploaders/document_uploader.rb',
   '../app/models/artifact.rb',
-  '../app/models/execution_error.rb'
+  '../app/models/execution_error.rb',
+
+  # monkey patches :(
+  './ext/measure.rb'
 ].each { |relative_path| load_external_validation_dependency(relative_path) }
 
-class QRDAProductTest < Cypress::QRDAProductTest; end
-class InpatientProductTest < Cypress::InpatientProductTest; end
+Measure = Cypress::Measure
+QRDAProductTest = Cypress::QRDAProductTest
+InpatientProductTest = Cypress::InpatientProductTest
 module Validators
   include Cypress::Validators
 end
+
+# load HQMF from health-data-standards' lib folder
+Gem.find_files("hqmf-parser.rb").each{|f| require f}

--- a/lib/includes_for_external_validation.rb
+++ b/lib/includes_for_external_validation.rb
@@ -5,6 +5,7 @@ require 'devise/orm/mongoid'
 require 'carrierwave'
 require 'carrierwave/mongoid'
 require 'health-data-standards'
+require 'health-data-standards/hqmf-parser'
 require 'quality-measure-engine'
 
 module Cypress
@@ -65,7 +66,7 @@ module Validators
 end
 
 # load HQMF from health-data-standards' lib folder
-Gem.find_files("hqmf-parser.rb").each{|f| require f}
+Gem.find_files('hqmf-parser.rb').each { |f| require f }
 
 APP_CONFIG = {
   'file_upload_root' => File.absolute_path('./tmp'),

--- a/lib/includes_for_external_validation.rb
+++ b/lib/includes_for_external_validation.rb
@@ -66,3 +66,10 @@ end
 
 # load HQMF from health-data-standards' lib folder
 Gem.find_files("hqmf-parser.rb").each{|f| require f}
+
+APP_CONFIG = {
+  'file_upload_root' => File.absolute_path('./tmp'),
+  'effective_date'   => {
+    'year' => '2013'
+  }
+}

--- a/lib/includes_for_external_validation.rb
+++ b/lib/includes_for_external_validation.rb
@@ -31,6 +31,10 @@ end
   './validators/smoking_gun_validator.rb',
   './cypress/qrda_file_constants.rb',
   './validators/qrda_file_validator.rb',
+  './validators/qrda_cat1_validator.rb',
+  './validators/qrda_cat3_validator.rb',
+  './validators/expected_results_validator.rb',
+  './validators/measure_period_validator.rb',
 
   # product tests
   '../app/models/product.rb',
@@ -49,3 +53,9 @@ end
   '../app/models/artifact.rb',
   '../app/models/execution_error.rb'
 ].each { |relative_path| load_external_validation_dependency(relative_path) }
+
+class QRDAProductTest < Cypress::QRDAProductTest; end
+class InpatientProductTest < Cypress::InpatientProductTest; end
+module Validators
+  include Cypress::Validators
+end

--- a/lib/validators/qrda_cat3_validator.rb
+++ b/lib/validators/qrda_cat3_validator.rb
@@ -1,4 +1,3 @@
-require 'validators/qrda_cat1_validator'
 module Validators
     class QrdaCat3Validator < QrdaFileValidator
   include HealthDataStandards::Validate

--- a/lib/validators/qrda_file_validator.rb
+++ b/lib/validators/qrda_file_validator.rb
@@ -1,9 +1,6 @@
 require 'quality-measure-engine'
 module Validators
   class QrdaFileValidator
-
-    require_relative '../cypress/qrda_file_constants'
-
     def get_document(doc)
       doc = (doc.kind_of? String )? Nokogiri::XML(doc) : doc
       raise ArgumentError, 'Argument was not an XML document' unless doc.root

--- a/lib/validators/qrda_file_validator.rb
+++ b/lib/validators/qrda_file_validator.rb
@@ -2,7 +2,7 @@ require 'quality-measure-engine'
 module Validators
   class QrdaFileValidator
 
-    require 'cypress/qrda_file_constants'
+    require_relative '../cypress/qrda_file_constants'
 
     def get_document(doc)
       doc = (doc.kind_of? String )? Nokogiri::XML(doc) : doc

--- a/test/factories/products.rb
+++ b/test/factories/products.rb
@@ -1,4 +1,12 @@
 FactoryGirl.define do
+  factory :external_validation_product, class: Cypress::Product do
+    user_ids  { [FactoryGirl.create(:external_validation_user).id] }
+    vendor_id { FactoryGirl.create(:external_validation_vendor).id }
+
+    name 'Dat App'
+    version ''
+    description ''
+  end
 
   factory :product_1 do
     name "Vendor 1 Product 1"

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,6 +1,28 @@
 FactoryGirl.define do
-  
-  factory :bobby do 
+  factory :external_validation_user, class: Cypress::User do
+    product_ids []
+    email { FFaker::Internet.email }
+    encrypted_password 'supersecretencryptedpassword'
+    first_name { FFaker::Name.first_name }
+    last_name { FFaker::Name.last_name }
+    telephone ''
+    reset_password_token 'supersecretresetpasswordtoken'
+    remember_created_at nil
+    sign_in_count 8
+    current_sign_in_ip '192.168.1.1'
+    last_sign_in_ip '192.168.1.1'
+    admin true
+    approved true
+    staff_role nil
+    disabled false
+    failed_attempts 0
+    locked_at nil
+    password 'Passw0rd!'
+    password_confirmation 'Passw0rd!'
+    terms_and_conditions '1'
+  end
+
+  factory :bobby do
     first_name  "bobby"
     last_name  "tables"
     telephone "867-5309"
@@ -8,5 +30,5 @@ FactoryGirl.define do
     # "product_ids":["4f6b77831d41c851eb0004a5""4f636ae01d41c851eb00048e""4f57a88a1d41c851eb000004"]
     #     product_test_ids :["4f6b78801d41c851eb0004a7""4f5a606b1d41c851eb000484""4f636b3f1d41c851eb000491""4f58f8de1d41c851eb000478"]
   end
-  
+
 end

--- a/test/factories/vendors.rb
+++ b/test/factories/vendors.rb
@@ -1,7 +1,28 @@
 FactoryGirl.define do
-  
+  factory :external_validation_vendor, class: Cypress::Vendor do
+    name 'Zeal LLC'
+    url ''
+    address ''
+    state ''
+    zip ''
+    poc ''
+    email ''
+    tel ''
+    fax ''
+    vendor_id ''
+    accounts_poc ''
+    accounts_email ''
+    accounts_tel ''
+    tech_poc ''
+    tech_email ''
+    tech_tel ''
+    press_poc ''
+    press_email ''
+    press_tel ''
+  end
+
   factory :ehr1 do
-    
+
     products   {[Factory.build(:product)]}
     name    "Test EHR Vendor 1"
     vendor_id    "1"
@@ -26,8 +47,8 @@ FactoryGirl.define do
     press_email    "gary@example.com"
     press_tel    "555-555-5555"
   end
-  
-  
+
+
   factory :ehr2 do
 
   	name  "Test EHR Vendor 2"
@@ -50,5 +71,5 @@ FactoryGirl.define do
   	press_email  "gary@example.com"
   	press_tel  "555-555-5555"
    end
-  
+
 end


### PR DESCRIPTION
In order to allow projects to validate their cat3 files against a cypress ProductTest's expected results, we need to make those libraries available outside of the cypress web app. One approach could be creating a gem which encapsulates this, which could be an approach down the line. Another could be setting up a specific web endpoint which would do the validation on an external platform; however, that could make automated testing brittle should the host be unresponsive.

This approach simply allows the validating project to include the `lib/includes_for_external_validation.rb` file and have access to all of the classes and libraries which are used for validation.
